### PR TITLE
Updated is_power_of_2 function. Old one was incorrect

### DIFF
--- a/internals.cpp
+++ b/internals.cpp
@@ -42,7 +42,7 @@ namespace
 
     bool is_power_of_2(size_t n)
     {
-        return (n & (n >> 1)) == 0;
+        return ((n != 0) && !(n & (n - 1))); 
     }
 }
 


### PR DESCRIPTION
Old implementation of is_power_of_2 was incorrect. E.g. it returned true on n=20
